### PR TITLE
add missing copy commands

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,2 +1,8 @@
 # Note that there must be a tag
 FROM pangeo/pangeo-ocean:2019.03.11
+
+# https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile
+COPY . ${HOME}
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+USER ${NB_USER}


### PR DESCRIPTION
I forgot to copy the repo contents to the home directory:
https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile